### PR TITLE
Apply pthread also to mosquitto_sub and mosquitto_pub

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -74,7 +74,7 @@ class MosquittoConan(ConanFile):
         self.copy(pattern="LICENSE.txt", dst="licenses", src=self.source_subfolder)
         self.copy(pattern="edl-v10", dst="licenses", src=self.source_subfolder)
         self.copy(pattern="epl-v10", dst="licenses", src=self.source_subfolder)
-        self.copy(pattern="*mosquitto.conf", dst="bin", src=self.source_subfolder)
+        self.copy(pattern="mosquitto.conf", src=self.source_subfolder, dst="bin")
         cmake = self.configure_cmake()
         cmake.install()
 

--- a/conanfile.py
+++ b/conanfile.py
@@ -74,6 +74,7 @@ class MosquittoConan(ConanFile):
         self.copy(pattern="LICENSE.txt", dst="licenses", src=self.source_subfolder)
         self.copy(pattern="edl-v10", dst="licenses", src=self.source_subfolder)
         self.copy(pattern="epl-v10", dst="licenses", src=self.source_subfolder)
+        self.copy(pattern="*mosquitto.conf", dst="bin", src=self.source_subfolder)
         cmake = self.configure_cmake()
         cmake.install()
 
@@ -85,7 +86,7 @@ class MosquittoConan(ConanFile):
         self.copy_deps("*.dll", src="lib", dst="bin")
         self.copy("*.so*", src="lib", dst="bin")
         self.copy_deps("*.so*", src="lib", dst="bin")
-        self.copy("mosquitto.conf", src="etc/mosquitto/", dst="bin")
+        self.copy("mosquitto.conf", src="bin", dst="bin")
 
     def package_info(self):
         self.cpp_info.libs = tools.collect_libs(self)

--- a/mosquitto.patch
+++ b/mosquitto.patch
@@ -1,3 +1,19 @@
+diff --git a/client/CMakeLists.txt b/client/CMakeLists.txt
+index 0b6f420..41d00f3 100644
+--- a/client/CMakeLists.txt
++++ b/client/CMakeLists.txt
+@@ -11,8 +11,9 @@ endif (${WITH_SRV} STREQUAL ON)
+ add_executable(mosquitto_pub pub_client.c ${shared_src})
+ add_executable(mosquitto_sub sub_client.c ${shared_src})
+
+-target_link_libraries(mosquitto_pub libmosquitto)
+-target_link_libraries(mosquitto_sub libmosquitto)
++find_package(Threads)
++target_link_libraries(mosquitto_pub libmosquitto ${CMAKE_THREAD_LIBS_INIT})
++target_link_libraries(mosquitto_sub libmosquitto ${CMAKE_THREAD_LIBS_INIT})
+
+ install(TARGETS mosquitto_pub RUNTIME DESTINATION "${BINDIR}" LIBRARY DESTINATION "${LIBDIR}")
+ install(TARGETS mosquitto_sub RUNTIME DESTINATION "${BINDIR}" LIBRARY DESTINATION "${LIBDIR}")
 diff --git a/CMakeLists.txt b/CMakeLists.txt
 index 3a68061..8ac5476 100644
 --- a/CMakeLists.txt


### PR DESCRIPTION
While cross building it to ARM I found that the `mosquitto_sub` and `mosquitto_pub` failed to link because of missing pthread.