### PR TITLE
Let mosquitto's cmake know if we don't want TLS

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -51,6 +51,7 @@ class MosquittoConan(ConanFile):
 
     def _configure_cmake(self):
         cmake = CMake(self)
+        cmake.definitions["WITH_TLS"] = self.options.with_tls
         cmake.definitions["WITH_SRV"] = self.options.with_srv
         cmake.definitions["WITH_BINARIES"] = self.options.with_binaries
         cmake.definitions["WITH_MOSQUITTOPP"] = self.options.with_mosquittopp


### PR DESCRIPTION
Fix an issue when mosquitto won't compile without TLS because we don't
compile its OpenSSL dependency but mosquitto still looks for it.